### PR TITLE
Change 'Request Entity Too Large' to 'Payload Too Large'

### DIFF
--- a/main.md
+++ b/main.md
@@ -231,8 +231,8 @@ If the request object received is invalid, the authorization server shall return
 #### Method not allowed
 If the request did not use POST, the authorization server shall return `405 Method Not Allowed` HTTP error response.
 
-#### Request entity too large
-If the request size was beyond the upper bound that the authorization server allows, the authorization server shall return a `413 Request Entity Too Large` HTTP error response.
+#### Payload too large
+If the request size was beyond the upper bound that the authorization server allows, the authorization server shall return a `413 Payload Too Large` HTTP error response.
 
 #### Too many requests
 If the request from the client per a time period goes beyond the number the authorization server allows, the authorization server shall return a `429 Too Many Requests` HTTP error response.


### PR DESCRIPTION
In [RFC 2616](https://tools.ietf.org/html/rfc2616) (which has been obsoleted by [RFC 7231](https://tools.ietf.org/html/rfc7231)), the name of the HTTP status code 413 is `Request Entity Too Large`. In [RFC 7231](https://tools.ietf.org/html/rfc7231) (which has obsoleted [RFC 2616](https://tools.ietf.org/html/rfc2616)), the name is `Payload Too Large`. If "Pushed Authorization Requests" mentions the HTTP status code 413, `Payload Too Large` should be used instead of `Request Entity Too Large`.